### PR TITLE
NOISSUE - update agent doc to match the one in mainflux/agent

### DIFF
--- a/docs/agent.md
+++ b/docs/agent.md
@@ -123,7 +123,7 @@ Service commands are being sent via MQTT to topic:
 
 `channels/<control_channel_id>/messages/services/<service_name>/<subtopic>`
   
-when messages is received Agent forwards them to Nats on subject:
+when messages is received Agent forwards them to NATS on subject:
 
 `commands.<service_name>.<subtopic>`
 

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -117,7 +117,7 @@ Response can be observed on `channels/$CH/messages/res/#`
 
 ## Proxying commands
 
-You can send commands to other services that are subscribed on the same edge Nats server as Agent.
+You can send commands to services running on the same edge gateway as Agent if they are subscribed on same NATS server and correct subject.
 
 Service commands are being sent via MQTT to topic:
 

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -117,7 +117,17 @@ Response can be observed on `channels/$CH/messages/res/#`
 
 ## Proxying commands
 
-Agent is subscribed to `channels/<control_channel>/messages/services/#` MQTT topic. Messages published to `channels/<control_channel>/messages/services/<service_name>` will be published to NATS `services.<service_name>` so that service that is subscribed to that NATS subject can be controlled by these messages.
+You can send commands to other services that are subscribed on the same edge Nats server as Agent.
+
+Service commands are being sent via MQTT to topic:
+
+`channels/<control_channel_id>/messages/services/<service_name>/<subtopic>`
+  
+when messages is received Agent forwards them to Nats on subject:
+
+`commands.<service_name>.<subtopic>`
+
+Payload is up to the application and service itself.
 
 
 ## EdgeX 


### PR DESCRIPTION


### What does this do?

doc is wrong about the subject in which agent relays the service commands. 
Updated Proxying commands part to match the one in mainflux/agent repo

