### PR TITLE
NOISSUE - Replace swagger with openapi refs and add openapi refs

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -54,3 +54,4 @@ mosquitto_pub -u <thing_id> -P <thing_key> -t channels/<channel_id>/messages -h 
 ```
 mosquitto_sub -u <thing_id> -P <thing_key> --cafile docker/ssl/certs/ca.crt --cert docker/ssl/certs/<thing_cert_name>.crt --key docker/ssl/certs/<thing_cert_key>.key -t channels/<channel_id>/messages -h localhost -p 8883
 ```
+

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -121,4 +121,4 @@ curl -s -S -i -X PUT -H "Authorization: <user_token>" -H "Content-Type: applicat
 
 In order to disconnect, the same request should be sent with the value of `state` set to 0.
 
-For more information about Bootstrap API, please check out the [API documentation](https://github.com/mainflux/mainflux/blob/master/bootstrap/swagger.yml).
+For more information about the Bootstrap service API, please check out the [API documentation](https://github.com/mainflux/mainflux/blob/master/bootstrap/openapi.yml).

--- a/docs/certs.md
+++ b/docs/certs.md
@@ -55,3 +55,5 @@ In this mode certificates can also be revoked:
 ```bash
 curl -s -S -X DELETE http://localhost:8204/certs/revoke -H "Authorization: $TOK" -H 'Content-Type: application/json'   -d '{"thing_id":"c30b8842-507c-4bcd-973c-74008cef3be5"}'
 ```
+
+For more information about the Certification service API, please check out the [API documentation](https://github.com/mainflux/mainflux/blob/master/certs/openapi.yml).

--- a/docs/messaging.md
+++ b/docs/messaging.md
@@ -13,6 +13,8 @@ curl -s -S -i --cacert docker/ssl/certs/ca.crt -X POST -H "Authorization: <thing
 Note that if you're going to use senml message format, you should always send
 messages as an array.
 
+For more information about the HTTP messaging service API, please check out the [API documentation](https://github.com/mainflux/mainflux/blob/master/http/openapi.yml).
+
 ## MQTT
 
 To send and receive messages over MQTT you could use [Mosquitto tools](https://mosquitto.org),

--- a/docs/platform-management.md
+++ b/docs/platform-management.md
@@ -27,6 +27,8 @@ Response should look like this:
 }
 ```
 
+For more information about the Users service API, please check out the [API documentation](https://github.com/mainflux/mainflux/blob/master/users/openapi.yml).
+
 ## System provisioning
 
 Before proceeding, make sure that you have created a new account and obtained an authorization key.
@@ -311,3 +313,5 @@ If you want to disconnect your thing from the channel, send following request:
 ```bash
 curl -s -S -i --cacert docker/ssl/certs/ca.crt -X DELETE -H "Authorization: <user_auth_token>" https://localhost/channels/<channel_id>/things/<thing_id>
 ```
+
+For more information about the Things service API, please check out the [API documentation](https://github.com/mainflux/mainflux/blob/master/things/openapi.yml).

--- a/docs/provision.md
+++ b/docs/provision.md
@@ -270,3 +270,5 @@ Agent will retrieve connections parameters and connect to Mainflux cloud.
 [authn]: https://github.com/mainflux/mainflux/blob/master/authn/README.md
 [exp]: https://github.com/mainflux/export
 [cli]: https://github.com/mainflux/mainflux/tree/master/cli
+
+For more information about the Provision service API, please check out the [API documentation](https://github.com/mainflux/mainflux/blob/master/provision/openapi.yml).

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -75,7 +75,7 @@ Readers provide an implementation of various `message readers`.
 Message readers are services that consume normalized (in `SenML` format) Mainflux messages from data storage and opens HTTP API for message consumption.
 Installing corresponding writer before reader is implied.
 
-Each of the Reader services exposes the same [HTTP API](https://github.com/mainflux/mainflux/blob/master/readers/swagger.yml) for fetching messages on its default port.
+Each of the Reader services exposes the same [HTTP API](https://github.com/mainflux/mainflux/blob/master/readers/openapi.yml) for fetching messages on its default port.
 
 To read sent messages on channel with id `channel_id` you should send `GET` request to `/channels/<channel_id>/messages` with thing access token in `Authorization` header. That thing must be connected to  channel with `channel_id`
 

--- a/docs/twins.md
+++ b/docs/twins.md
@@ -197,7 +197,7 @@ Twin belongs to a Mainflux user, tenant representing a physical person or an org
 
 ### TWIN operations
 
-For the full and up to date Mainflux twins service HTTP API please refer to the [twins service swagger file](https://github.com/mainflux/mainflux/blob/master/twins/swagger.yaml).
+For more information about the Twins service API, please check out the [API documentation](https://github.com/mainflux/mainflux/blob/master/twins/openapi.yml).
 
 #### Create && Update
 


### PR DESCRIPTION
Recently, in the Mainflux platform, we miggrated from swagger 2 to openapi 3 spec. We also renamed the corresponding `swagger.yml` to `openapi.yml` file. Consequently, we need to change the references to those files in the docs.