### PR TITLE
MF-68 - Fix link to Auth service in provision page

### DIFF
--- a/docs/provision.md
+++ b/docs/provision.md
@@ -127,13 +127,13 @@ Example of provision layout below
 
 ## Authentication
 In order to create necessary entities provision service needs to authenticate against Mainflux.
-To provide authentication credentials to the provision service you can pass it in as an environment variable or in a config file as Mainflux user and password or as API token (that can be issued on `/users` or `/keys` endpoint of [authn][authn].
+To provide authentication credentials to the provision service you can pass it in as an environment variable or in a config file as Mainflux user and password or as API token (that can be issued on `/users` or `/keys` endpoint of [auth][auth].
 
 Additionally, users or API token can be passed in Authorization header, this authentication takes precedence over others.
 
 * `username`, `password` - (`MF_PROVISION_USER`, `MF_PROVISION_PASSWORD` in [.env][env], `mf_user`, `mf_pass` in [config.toml][conftoml]
 * API Key - (`MF_PROVISION_API_KEY` in [.env][env] or [config.toml][conftoml]
-* `Authorization: Token|ApiKey` - request authorization header containing either users token or API key. Check [authn][authn].
+* `Authorization: Token|ApiKey` - request authorization header containing either users token or API key. Check [auth][auth].
 
 ## Running
 Provision service can be run as a standalone or in docker composition as addon to the core docker composition.
@@ -267,7 +267,7 @@ Agent will retrieve connections parameters and connect to Mainflux cloud.
 [config]: https://github.com/mainflux/mainflux/tree/master/provision#configuration
 [env]: https://github.com/mainflux/mainflux/blob/master/.env
 [conftoml]: https://github.com/mainflux/mainflux/blob/master/docker/addons/provision/configs/config.toml
-[authn]: https://github.com/mainflux/mainflux/blob/master/authn/README.md
+[auth]: https://github.com/mainflux/mainflux/blob/master/auth/README.md
 [exp]: https://github.com/mainflux/export
 [cli]: https://github.com/mainflux/mainflux/tree/master/cli
 

--- a/docs/provision.md
+++ b/docs/provision.md
@@ -4,17 +4,17 @@ Provisioning is a process of configuration of an IoT platform in which system op
 
 For provisioning we can use [Mainflux CLI][cli] for creating users and for each node in the edge (eg. gateway) required number of things, channels, connecting them and creating certificates if needed.
 
-Provision service is used to set up initial application configuration once user is created. Provision service creates  things, channels, connections and certificates. Once user is created we can use provision to create a setup for edge node in one HTTP request instead of issuing several CLI commands. 
+Provision service is used to set up initial application configuration once user is created. Provision service creates  things, channels, connections and certificates. Once user is created we can use provision to create a setup for edge node in one HTTP request instead of issuing several CLI commands.
 
-Provision service provides an HTTP API to interact with [Mainflux][mainflux].  
+Provision service provides an HTTP API to interact with [Mainflux][mainflux].
 
-For gateways to communicate with [Mainflux][mainflux] configuration is required (MQTT host, thing, channels, certificates...). Gateway will send a request to [Bootstrap][bootstrap] service providing `<external_id>` and `<external_key>` in HTTP request to get the configuration. To make a request to [Bootstrap][bootstrap] service you can use [Agent][agent] service on a gateway.  
+For gateways to communicate with [Mainflux][mainflux] configuration is required (MQTT host, thing, channels, certificates...). Gateway will send a request to [Bootstrap][bootstrap] service providing `<external_id>` and `<external_key>` in HTTP request to get the configuration. To make a request to [Bootstrap][bootstrap] service you can use [Agent][agent] service on a gateway.
 
-To create bootstrap configuration you can use [Bootstrap][bootstrap] or `Provision` service. [Mainflux UI][mfxui] uses [Bootstrap][bootstrap] service for creating gateway configurations. `Provision` service should provide an easy way of provisioning your gateways i.e creating bootstrap configuration and as many things and channels that your setup requires.  
+To create bootstrap configuration you can use [Bootstrap][bootstrap] or `Provision` service. [Mainflux UI][mfxui] uses [Bootstrap][bootstrap] service for creating gateway configurations. `Provision` service should provide an easy way of provisioning your gateways i.e creating bootstrap configuration and as many things and channels that your setup requires.
 
-Also, you may use provision service to create certificates for each thing. Each service running on gateway may require more than one thing and channel for communication. 
-If, for example, you are using services [Agent][agent] and [Export][exp] on a gateway you will need two channels for `Agent` (`data` and `control`) and one thing for `Export`. 
-Additionally, if you enabled mTLS each service will need its own thing and certificate for access to [Mainflux][mainflux]. 
+Also, you may use provision service to create certificates for each thing. Each service running on gateway may require more than one thing and channel for communication.
+If, for example, you are using services [Agent][agent] and [Export][exp] on a gateway you will need two channels for `Agent` (`data` and `control`) and one thing for `Export`.
+Additionally, if you enabled mTLS each service will need its own thing and certificate for access to [Mainflux][mainflux].
 Your setup could require any number of things and channels, this kind of setup we can call `provision layout`.
 
 Provision service provides a way of specifying this `provision layout` and creating a setup according to that layout by serving requests on `/mapping` endpoint. Provision layout is configured in [config.toml][conftoml].
@@ -24,15 +24,15 @@ Provision service provides a way of specifying this `provision layout` and creat
 The service is configured using the environment variables presented in the following [table][config]. Note that any unset variables will be replaced with their default values.
 
 
-By default, call to `/mapping` endpoint will create one thing and two channels (`control` and `data`) and connect it as this is typical setup required by [Agent](agent.md). If there is a requirement for different provision layout we can use [config][conftoml] file in addition to environment variables. 
+By default, call to `/mapping` endpoint will create one thing and two channels (`control` and `data`) and connect it as this is typical setup required by [Agent](agent.md). If there is a requirement for different provision layout we can use [config][conftoml] file in addition to environment variables.
 
-For the purposes of running provision as an add-on in docker composition environment variables seems more suitable. Environment variables are set in [.env][env].  
+For the purposes of running provision as an add-on in docker composition environment variables seems more suitable. Environment variables are set in [.env][env].
 
 Configuration can be specified in [config.toml][conftoml]. Config file can specify all the settings that environment variables can configure and in addition `/mapping` endpoint provision layout can be configured.
 
 In `config.toml` we can enlist an array of things and channels that we want to create and make connections between them which we call provision layout.
 
-Things Metadata can be whatever suits your needs. Thing that has metadata with `external_id` will have bootstrap configuration created, `external_id` value will be populated with value from [request](#example)). 
+Things Metadata can be whatever suits your needs. Thing that has metadata with `external_id` will have bootstrap configuration created, `external_id` value will be populated with value from [request](#example)).
 Bootstrap configuration can be fetched with [Agent][agent]. For channel's metadata `type` is reserved for `control` and `data` which we use with [Agent][agent].
 
 Example of provision layout below
@@ -55,13 +55,13 @@ Example of provision layout below
     [bootstrap.content.agent.server]
       nats_url = "localhost:4222"
       port = "9000"
-  
+
     [bootstrap.content.agent.heartbeat]
       interval = "30s"
-  
+
     [bootstrap.content.agent.terminal]
       session_timeout = "30s"
-    
+
     [bootstrap.content.export.exp]
       log_level = "debug"
       nats = "nats://localhost:4222"
@@ -89,7 +89,7 @@ Example of provision layout below
       subtopic = ""
       type = "mfx"
       workers = 10
-    
+
     [[bootstrap.content.export.routes]]
       mqtt_topic = ""
       nats_topic = "export"
@@ -126,8 +126,8 @@ Example of provision layout below
 `[bootstrap.content]` will be marshalled and saved into `content` field in bootstrap configs when request to `/mappings` is made, `content` field from bootstrap config is used to create `Agent` and `Export` configuration files upon `Agent` fetching bootstrap configuration.
 
 ## Authentication
-In order to create necessary entities provision service needs to authenticate against Mainflux. 
-To provide authentication credentials to the provision service you can pass it in as an environment variable or in a config file as Mainflux user and password or as API token (that can be issued on `/users` or `/keys` endpoint of [authn][authn]. 
+In order to create necessary entities provision service needs to authenticate against Mainflux.
+To provide authentication credentials to the provision service you can pass it in as an environment variable or in a config file as Mainflux user and password or as API token (that can be issued on `/users` or `/keys` endpoint of [authn][authn].
 
 Additionally, users or API token can be passed in Authorization header, this authentication takes precedence over others.
 


### PR DESCRIPTION
### What does this do?
Fix error to Auth service in provision page.

### Which issue(s) does this PR fix/relate to?
Resolves #68.

### List any changes that modify/break current functionality

### Have you included tests for your changes?

### Did you document any new/modified functionality?

### Notes
It seems that there are also few words with Authn in the kubernetes page, but I didn't know if it is still relevant.