### PR TITLE
MF-70 - Get the dependent charts from bitnami

### DIFF
--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -22,7 +22,7 @@ Helm is the package manager for Kubernetes. Follow [these instructions](https://
 ### Stable Helm Repository
 Add a stable chart repository:
 ```bash
-helm repo add stable https://kubernetes-charts.storage.googleapis.com/
+helm repo add bitnami https://charts.bitnami.com/bitnami
 ```
 
 ### Nginx Ingress Controller


### PR DESCRIPTION
The 'kubernetes-charts' no longer available hence the installation steps mentioned in the doc need an update.

### What does this do?

Updates the Kubernetes installation step to fix the Helm dependency issue

### Which issue(s) does this PR fix/relate to?
Resolves #70

### Local Validation 
dramasam@Dineshs-MacBook-Pro mainflux % helm repo add bitnami https://charts.bitnami.com/bitnami
"bitnami" has been added to your repositories
dramasam@Dineshs-MacBook-Pro mainflux % helm dependency update                                  
Hang tight while we grab the latest from your chart repositories...
...Successfully got an update from the "nginx-stable" chart repository
...Successfully got an update from the "bitnami" chart repository
...Successfully got an update from the "stable" chart repository
Update Complete. ⎈Happy Helming!⎈
Saving 13 charts
Downloading nats from repo https://charts.helm.sh/stable
Downloading postgresql from repo https://charts.bitnami.com/bitnami
Already downloaded postgresql from repo https://charts.bitnami.com/bitnami
Already downloaded postgresql from repo https://charts.bitnami.com/bitnami
Already downloaded postgresql from repo https://charts.bitnami.com/bitnami
Already downloaded postgresql from repo https://charts.bitnami.com/bitnami
Downloading redis from repo https://charts.bitnami.com/bitnami
Already downloaded redis from repo https://charts.bitnami.com/bitnami
Already downloaded redis from repo https://charts.bitnami.com/bitnami
Already downloaded redis from repo https://charts.bitnami.com/bitnami
Already downloaded redis from repo https://charts.bitnami.com/bitnami
Downloading influxdb from repo https://charts.bitnami.com/bitnami
Downloading mongodb from repo https://charts.bitnami.com/bitnami
Deleting outdated charts
dramasam@Dineshs-MacBook-Pro mainflux % 
