### PR TITLE
MF-70 - Get the dependent charts from bitnami

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -4,7 +4,13 @@ Mainflux CLI makes it easy to manage users, things, channels and messages.
 
 CLI can be downloaded as separate asset from [project realeses](https://github.com/mainflux/mainflux/releases) or it can be built with `GNU Make` tool:
 
+The [GOPATH](https://golang.org/doc/gopath_code) should be set and `go get` the `mainflux` code to build the cli successfully.
+
 ```bash
+# Get the mainflux code
+go get github.com/mainflux/mainflux
+
+# Build the mainflux-cli
 make cli
 ```
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -12,6 +12,14 @@ make run
 
 This will start Mainflux docker composition, which will output the logs from the containers.
 
+Check the containers are up and running before proceeding.
+
+```bash
+docker ps | grep -v Up
+```
+
+> Cleanup the container images and volumes by executing `make cleandocker` if any container is in 'Restarting' to ensure that the previous deployment doesn't affect the new one. This command removes all the data (i.e things, user etc). Please do not try this in the production environment.
+
 ## Step 2 - Install the CLI
 Open a new terminal from which you can interact with the running Mainflux system. The easiest way to do this is by using the Mainflux CLI,
 which can be downloaded as a tarball from GitHub (here we use release `0.9.0` but be sure to use the latest release):
@@ -21,6 +29,9 @@ wget -O- https://github.com/mainflux/mainflux/releases/download/0.9.0/mainflux-c
 ```
 
 > Make sure that `$GOBIN` is added to your `$PATH` so that `mainflux-cli` command can be accessible system-wide
+
+#### Build mainflux-cli
+Build `mainflux-cli` if the pre-built CLI is not compatible with your OS, i.e MacOS. Please see the [CLI](cli.md) for further details.
 
 ## Step 3 - Provision the System
 Once installed, you can use the CLI to quick-provision the system for testing:

--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -22,7 +22,7 @@ Helm is the package manager for Kubernetes. Follow [these instructions](https://
 ### Stable Helm Repository
 Add a stable chart repository:
 ```bash
-helm repo add stable https://kubernetes-charts.storage.googleapis.com/
+helm repo add bitnami https://charts.bitnami.com/bitnami
 ```
 
 ### Nginx Ingress Controller


### PR DESCRIPTION
The 'kubernetes-charts' no longer available hence the installation steps mentioned in the doc need an update.

### What does this do?

Updates the Kubernetes installation step to fix the Helm dependency issue

### Which issue(s) does this PR fix/relate to?
Resolves #70

### Local Validation 
dramasam@Dineshs-MacBook-Pro mainflux % helm repo add bitnami https://charts.bitnami.com/bitnami
"bitnami" has been added to your repositories
dramasam@Dineshs-MacBook-Pro mainflux % helm dependency update                                  
Hang tight while we grab the latest from your chart repositories...
...Successfully got an update from the "nginx-stable" chart repository
...Successfully got an update from the "bitnami" chart repository
...Successfully got an update from the "stable" chart repository
Update Complete. ⎈Happy Helming!⎈
Saving 13 charts
Downloading nats from repo https://charts.helm.sh/stable
Downloading postgresql from repo https://charts.bitnami.com/bitnami
Already downloaded postgresql from repo https://charts.bitnami.com/bitnami
Already downloaded postgresql from repo https://charts.bitnami.com/bitnami
Already downloaded postgresql from repo https://charts.bitnami.com/bitnami
Already downloaded postgresql from repo https://charts.bitnami.com/bitnami
Downloading redis from repo https://charts.bitnami.com/bitnami
Already downloaded redis from repo https://charts.bitnami.com/bitnami
Already downloaded redis from repo https://charts.bitnami.com/bitnami
Already downloaded redis from repo https://charts.bitnami.com/bitnami
Already downloaded redis from repo https://charts.bitnami.com/bitnami
Downloading influxdb from repo https://charts.bitnami.com/bitnami
Downloading mongodb from repo https://charts.bitnami.com/bitnami
Deleting outdated charts
dramasam@Dineshs-MacBook-Pro mainflux % 