### PR TITLE
NOISSUE - Change repo link to mainflux core

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,13 +4,17 @@
 #
 
 copyright: Copyright (c) Mainflux
-repo_url: https://github.com/mainflux/docs
+repo_url: https://github.com/mainflux/mainflux
 site_description: Mainflux IoT System
 site_name: Mainflux
+site_url: https://docs.mainflux.io
+edit_uri: ""
 theme:
   name: material
   logo: img/logo.png
   favicon: img/logo.png
+  icon:
+    repo: fontawesome/brands/github
 
 markdown_extensions:
   - admonition


### PR DESCRIPTION
Signed-off-by: Ivan Milosevic <iva@blokovi.com>

### What does this do?
Change repo link in the header of mkdocs published on github pages to mainflux core (instead of docs repo)

