### PR TITLE
NOISSUE - Add current version of go and protoc

### DIFF
--- a/docs/dev-guide.md
+++ b/docs/dev-guide.md
@@ -15,13 +15,13 @@ cd $SOMEPATH/mainflux
 
 ### Prerequisites
 
-Make sure that you have [Protocol Buffers](https://developers.google.com/protocol-buffers/) (version 3.11.4) compiler (`protoc`) installed.
+Make sure that you have [Protocol Buffers](https://developers.google.com/protocol-buffers/) (version 3.19.1) compiler (`protoc`) installed.
 
 [Go Protobuf](https://github.com/golang/protobuf) installation instructions are [here](https://github.com/golang/protobuf#installation).
 Go Protobuf uses C bindings, so you will need to install [C++ protobuf](https://github.com/google/protobuf) as a prerequisite.
 Mainflux uses `Protocol Buffers for Go with Gadgets` to generate faster marshaling and unmarshaling Go code. Protocol Buffers for Go with Gadgets installation instructions can be found [here](https://github.com/gogo/protobuf).
 
-A copy of [Go](https://golang.org/doc/install) (version 1.13.3) and docker template (version 3.7) will also need to be installed on your system.
+A copy of [Go](https://golang.org/doc/install) (version 1.17.5) and docker template (version 3.7) will also need to be installed on your system.
 
 If any of these versions seem outdated, the latest can always be found in our [CI script](https://github.com/mainflux/mainflux/blob/master/scripts/ci.sh).
 


### PR DESCRIPTION
Signed-off-by: Rodney Osodo <blackd0t@protonmail.com>

### What does this do?
Adds to the documentation the new updated versions of golang and protoc

### Which issue(s) does this PR fix/relate to?
It doesn't relate to previous issues

### List any changes that modify/break current functionality
No changes

### Have you included tests for your changes?
No tests

### Did you document any new/modified functionality?
Yes
