### PR TITLE
NOISSUE - Add Contenty Type to HTTP Publish Endpoint

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -659,7 +659,7 @@ Sends message via HTTP protocol
 > Must-have: `thing_key` and `channel_id`
 
 ```bash
-curl -s -S -i -X POST -H "Content-Type: application/json" -H "Authorization: Thing <thing_key>" http://localhost/http/channels/<channel_id>/messages -d '[{"bn":"some-base-name:","bt":1.276020076001e+09,"bu":"A","bver":5,"n":"voltage","u":"V","v":120.1}, {"n":"current","t":-5,"v":1.2}, {"n":"current","t":-4,"v":1.3}]'
+curl -s -S -i -X POST -H "Content-Type: application/senml+json" -H "Authorization: Thing <thing_key>" http://localhost/http/channels/<channel_id>/messages -d '[{"bn":"some-base-name:","bt":1.276020076001e+09,"bu":"A","bver":5,"n":"voltage","u":"V","v":120.1}, {"n":"current","t":-5,"v":1.2}, {"n":"current","t":-4,"v":1.3}]'
 ```
 
 Response:

--- a/docs/messaging.md
+++ b/docs/messaging.md
@@ -9,7 +9,7 @@ of message publishing for each of the supported protocols.
 To publish message over channel, thing should send following request:
 
 ```
-curl -s -S -i --cacert docker/ssl/certs/ca.crt -X POST -H "Content-Type: application/json" -H "Authorization: Thing <thing_key>" https://localhost/http/channels/<channel_id>/messages -d '[{"bn":"some-base-name:","bt":1.276020076001e+09, "bu":"A","bver":5, "n":"voltage","u":"V","v":120.1}, {"n":"current","t":-5,"v":1.2}, {"n":"current","t":-4,"v":1.3}]'
+curl -s -S -i --cacert docker/ssl/certs/ca.crt -X POST -H "Content-Type: application/senml+json" -H "Authorization: Thing <thing_key>" https://localhost/http/channels/<channel_id>/messages -d '[{"bn":"some-base-name:","bt":1.276020076001e+09, "bu":"A","bver":5, "n":"voltage","u":"V","v":120.1}, {"n":"current","t":-5,"v":1.2}, {"n":"current","t":-4,"v":1.3}]'
 ```
 
 Note that if you're going to use senml message format, you should always send

--- a/docs/messaging.md
+++ b/docs/messaging.md
@@ -9,7 +9,7 @@ of message publishing for each of the supported protocols.
 To publish message over channel, thing should send following request:
 
 ```
-curl -s -S -i --cacert docker/ssl/certs/ca.crt -X POST -H "Authorization: Thing <thing_key>" https://localhost/http/channels/<channel_id>/messages -d '[{"bn":"some-base-name:","bt":1.276020076001e+09, "bu":"A","bver":5, "n":"voltage","u":"V","v":120.1}, {"n":"current","t":-5,"v":1.2}, {"n":"current","t":-4,"v":1.3}]'
+curl -s -S -i --cacert docker/ssl/certs/ca.crt -X POST -H "Content-Type: application/json" -H "Authorization: Thing <thing_key>" https://localhost/http/channels/<channel_id>/messages -d '[{"bn":"some-base-name:","bt":1.276020076001e+09, "bu":"A","bver":5, "n":"voltage","u":"V","v":120.1}, {"n":"current","t":-5,"v":1.2}, {"n":"current","t":-4,"v":1.3}]'
 ```
 
 Note that if you're going to use senml message format, you should always send


### PR DESCRIPTION
### What does this do?
It adds content type json when publishing messages using http endpoint

### Which issue(s) does this PR fix/relate to?
N/A

### List any changes that modify/break current functionality
No

### Have you included tests for your changes?
No

### Did you document any new/modified functionality?
No

### Notes

#### Before 
```bash
curl -s -S -i -X POST -H "Authorization: Thing 5b5339fc-edff-47e4-a05e-0704fafbacde" http://localhost/http/channels/8448a12c-d5a2-4ba6-bcdd-c8676fa7a36c/messages -d '[{"bn":"some-base-name:","bt":1.276020076001e+09, "bu":"A","bver":5, "n":"voltage","u":"V","v":120.1}, {"n":"current","t":-5,"v":1.2}, {"n":"current","t":-4,"v":1.3}]'
HTTP/1.1 415 Unsupported Media Type
Server: nginx/1.20.0
Date: Mon, 26 Dec 2022 09:12:03 GMT
Content-Type: text/plain; charset=utf-8
Content-Length: 37
Connection: keep-alive

{"error":"unsupported content type"}
```

#### After
```bash
curl -s -S -i -X POST -H "Content-Type: application/json" -H "Authorization: Thing 5b5339fc-edff-47e4-a05e-0704fafbacde" http://localhost/http/channels/8448a12c-d5a2-4ba6-bcdd-c8676fa7a36c/messages -d '[{"bn":"some-base-name:","bt":1.276020076001e+09, "bu":"A","bver":5, "n":"voltage","u":"V","v":120.1}, {"n":"current","t":-5,"v":1.2}, {"n":"current","t":-4,"v":1.3}]'
HTTP/1.1 202 Accepted
Server: nginx/1.20.0
Date: Mon, 26 Dec 2022 09:13:11 GMT
Content-Length: 0
Connection: keep-alive


```
