### PR TITLE
NOISSUE - Add missing client-id (thing_name) argument in Mosquitto commands for mTLS docs

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -109,10 +109,10 @@ curl -s -S -i --cacert docker/ssl/certs/ca.crt --cert docker/ssl/certs/<thing_ce
 
 #### Publish
 ```bash
-mosquitto_pub -u <thing_id> -P <thing_key> -t channels/<channel_id>/messages -h localhost -p 8883  --cafile docker/ssl/certs/ca.crt --cert docker/ssl/certs/<thing_cert_name>.crt --key docker/ssl/certs/<thing_cert_key>.key -m '[{"bn":"some-base-name:","bt":1.276020076001e+09, "bu":"A","bver":5, "n":"voltage","u":"V","v":120.1}, {"n":"current","t":-5,"v":1.2}, {"n":"current","t":-4,"v":1.3}]'
+mosquitto_pub -i <thing_name> -u <thing_id> -P <thing_key> -t channels/<channel_id>/messages -h localhost -p 8883  --cafile docker/ssl/certs/ca.crt --cert docker/ssl/certs/<thing_cert_name>.crt --key docker/ssl/certs/<thing_cert_key>.key -m '[{"bn":"some-base-name:","bt":1.276020076001e+09, "bu":"A","bver":5, "n":"voltage","u":"V","v":120.1}, {"n":"current","t":-5,"v":1.2}, {"n":"current","t":-4,"v":1.3}]'
 ```
 
 #### Subscribe
 ```
-mosquitto_sub -u <thing_id> -P <thing_key> --cafile docker/ssl/certs/ca.crt --cert docker/ssl/certs/<thing_cert_name>.crt --key docker/ssl/certs/<thing_cert_key>.key -t channels/<channel_id>/messages -h localhost -p 8883
+mosquitto_sub -i <thing_name> -u <thing_id> -P <thing_key> --cafile docker/ssl/certs/ca.crt --cert docker/ssl/certs/<thing_cert_name>.crt --key docker/ssl/certs/<thing_cert_key>.key -t channels/<channel_id>/messages -h localhost -p 8883
 ```


### PR DESCRIPTION
Pull request title should be `MF-XXX - description` or `NOISSUE - description` where XXX is ID of issue that this PR relate to.
Please review the [CONTRIBUTING.md](./CONTRIBUTING.md) file for detailed contributing guidelines.

### What does this do?
Adds missing `-i <thing_name>` argument in mosquitto commands for MQTTS under the following mTLS documentation: https://docs.mainflux.io/authentication/#mutual-tls-authentication-with-x509-certificates

### Which issue(s) does this PR fix/relate to?
No issue created, since the change is quite small.

### List any changes that modify/break current functionality
Just a minor docs fix. No breaking change.

### Have you included tests for your changes?
This is documentation change, no need.

### Did you document any new/modified functionality?
Not applicable.
