### PR TITLE
NOISSUE - Add Requirements File

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Documentation is auto-generated from Markdown files in this repo.
 
 Install [MkDocs](https://www.mkdocs.org/#installation)
 ```
-pip install mkdocs
+pip install -r requirements.txt
 ```
 
 ## Install

--- a/README.md
+++ b/README.md
@@ -12,19 +12,18 @@ Documentation is auto-generated from Markdown files in this repo.
 
 > Additional practical information about Mainflux system, news and tutorials can be found on the [Mainflux blog][blog].
 
-## Prerequisites
-
-Install [MkDocs](https://www.mkdocs.org/#installation)
-```
-pip install -r requirements.txt
-```
-
 ## Install
 
 Doc repo can be fetched from GitHub:
 
 ```bash
 git clone git@github.com:mainflux/docs.git
+```
+
+Install [MkDocs](https://www.mkdocs.org/#installation)
+
+```bash
+pip install -r requirements.txt
 ```
 
 ## Usage

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,13 @@
+click==8.1.3
+ghp-import==2.1.0
+Jinja2==3.0.0
+Markdown==3.3.7
+MarkupSafe==2.1.2
+mergedeep==1.3.4
+mkdocs==1.4.2
+packaging==23.0
+python-dateutil==2.8.2
+PyYAML==6.0
+pyyaml_env_tag==0.1
+six==1.16.0
+watchdog==3.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
 click==8.1.3
 ghp-import==2.1.0
-Jinja2==3.0.0
+Jinja2==3.1.2
 Markdown==3.3.7
-MarkupSafe==2.1.2
+MarkupSafe==2.1.3
 mergedeep==1.3.4
-mkdocs==1.4.2
-packaging==23.0
+mkdocs==1.4.3
+packaging==23.1
 python-dateutil==2.8.2
 PyYAML==6.0
 pyyaml_env_tag==0.1


### PR DESCRIPTION
### What does this do?
Adds a requirement file to be able to install a specific version of `mkdocs` that runs well. When the version isn't set `mkdocs` fails as the latest jinja version breaks serving docs locally.

### Which issue(s) does this PR fix/relate to?
NOISSUE

### List any changes that modify/break current functionality
Introduces a requirements file to be able to install a specific version of mkdocs and jinja that works

### Have you included tests for your changes?
No

### Did you document any new/modified functionality?
No

### Notes
References https://github.com/mkdocs/mkdocs/issues/2799