### PR TITLE
NOISSUE - Fix Links on Edge.md

### DIFF
--- a/docs/edge.md
+++ b/docs/edge.md
@@ -376,11 +376,6 @@ MAINFLUX_USER_PASSWORD='12345678'
 
 `EXTERNAL_KEY` and `EXTERNAL_ID` are parameters posted to `/mapping` endpoint of `provision` service, `MAINFLUX_HOST` is location of cloud instance of Mainflux that `export` should connect to and `MAINFLUX_USER_EMAIL` and `MAINFLUX_USER_PASSWORD` are users credentials in the cloud.
 
-[conftoml]:(https://github.com/mainflux/export/blob/master/configs/config.toml)
-[docker-compose]:(https://github.com/mainflux/mainflux/docker/docker-compose.yml)
-[env]:(https://github.com/mainflux/export#environmet-variables)
-[agent]:(https://github.com/mainflux/agent)
-[protomsg]:(https://github.com/mainflux/mainflux/blob/master/pkg/messaging/message.proto)
 
 ## Example deployment
 
@@ -551,3 +546,9 @@ In Mainflux `mqtt` service:
 ```log
 mainflux-mqtt   | {"level":"info","message":"Publish - client ID export-88529fb2-6c1e-4b60-b9ab-73b5d89f7404 to the topic: channels/e2adcfa6-96b2-425d-8cd4-ff8cb9c056ce/messages/export/test","ts":"2020-05-08T15:16:02.999684791Z"}
 ```
+
+[conftoml]:https://github.com/mainflux/export/blob/master/configs/config.toml
+[docker-compose]:https://github.com/mainflux/mainflux/docker/docker-compose.yml
+[env]:(https://github.com/mainflux/export#environmet-variables)
+[agent]:(https://github.com/mainflux/agent)
+[protomsg]:https://github.com/mainflux/mainflux/blob/master/pkg/messaging/message.proto


### PR DESCRIPTION
### What does this do?
Fixes warnings on links regarding `edge.md`
```bash
INFO     -  Building documentation...
WARNING  -  Documentation file 'edge.md' contains a link to '(https:/github.com/mainflux/export/blob/master/configs/config.toml)' which is not found in the documentation files.
WARNING  -  Documentation file 'edge.md' contains a link to '(https:/github.com/mainflux/mainflux/blob/master/pkg/messaging/message.proto)' which is not found in the documentation files.
WARNING  -  Documentation file 'edge.md' contains a link to '(https:/github.com/mainflux/mainflux/docker/docker-compose.yml)' which is not found in the documentation files.
```

### Which issue(s) does this PR fix/relate to?
No issue

### List any changes that modify/break current functionality
None

### Have you included tests for your changes?
No

### Did you document any new/modified functionality?
No new functionality

### Notes
N/A