### PR TITLE
NOISSUE - Fix socket URL in messaging example

### DIFF
--- a/docs/messaging.md
+++ b/docs/messaging.md
@@ -133,7 +133,7 @@ func main() {
 	channelId := "30315311-56ba-484d-b500-c1e08305511f"
 	thingSecret := "c02ff576-ccd5-40f6-ba5f-c85377aad529"
 
-	socketUrl := "ws://localhost:8186/channels/" + channelId + "/messages/?authorization=" + thingKey
+	socketUrl := "ws://localhost:8186/channels/" + channelId + "/messages/?authorization=" + thingSecret
 
 	conn, _, err := websocket.DefaultDialer.Dial(socketUrl, nil)
 	if err != nil {


### PR DESCRIPTION
### What does this do?
The socket URL in the messaging.md file was incorrect. It was using the wrong variable for the authorization token. This commit fixes the issue by updating the variable to use the correct token (thingSecret) in the socket URL.

### Which issue(s) does this PR fix/relate to?

### List any changes that modify/break current functionality

### Have you included tests for your changes?

### Did you document any new/modified functionality?

### Notes
