### PR TITLE
NOISSUE - Updated bootstrap docs with detailed secure bootstrap config procedure

### DIFF
--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -122,7 +122,7 @@ In order to disconnect, the same request should be sent with the value of `state
 
 - *Encrypt the external key.*
 
-First, encrypt the external key of your thing using AES encryption. The encryption key is specified by the `MG_BOOTSTRAP_ENCRYPT_KEY` environment variable. Use a library or utility that supports AES encryption to do this. Here's an example of how to encrypt using go:
+First, encrypt the external key of your thing using AES encryption. The encryption key is specified by the `MG_BOOTSTRAP_ENCRYPT_KEY` environment variable. Use a library or utility that supports AES encryption to do this. Here's an example of how to encrypt using GO:
 
 ```go
 package main
@@ -177,6 +177,7 @@ Replace `<external_key>` and `<crypto_key>` with the thing's external key and `M
 
 
 Once the key is encrypted, make a request to the Bootstrap service. Here's how to do this using `curl`:
+
 ```bash
 curl --location 'http://localhost:9013/things/bootstrap/secure/<external_id>' \
 --header 'Accept: application/json' \
@@ -193,7 +194,7 @@ curl --location 'http://localhost:9013/things/bootstrap/secure/<external_id>' \
 
 - *Decrypt the response*
 
-Finally, decrypt the response using a function. Here's an example of how to do this using go:
+Finally, decrypt the response using a function. Here's an example of how to do this using GO:
 
 ```go
 package main

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -122,7 +122,8 @@ In order to disconnect, the same request should be sent with the value of `state
 
 - *Encrypt the external key.*
 
-First, encrypt the external key of your thing using AES encryption. The encryption key is specified by the `MG_BOOTSTRAP_ENCRYPT_KEY` environment variable. Use a library or utility that supports AES encryption to do this. Here's an example of how to encrypt using golang:
+First, encrypt the external key of your thing using AES encryption. The encryption key is specified by the `MG_BOOTSTRAP_ENCRYPT_KEY` environment variable. Use a library or utility that supports AES encryption to do this. Here's an example of how to encrypt using go:
+
 ```bash
 package main
 
@@ -192,7 +193,7 @@ curl --location 'http://localhost:9013/things/bootstrap/secure/<external_id>' \
 
 - *Decrypt the response*
 
-Finally, decrypt the response using a function. Here's an example of how to do this using golang:
+Finally, decrypt the response using a function. Here's an example of how to do this using go:
 
 ```bash
 package main

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -124,7 +124,7 @@ In order to disconnect, the same request should be sent with the value of `state
 
 First, encrypt the external key of your thing using AES encryption. The encryption key is specified by the `MG_BOOTSTRAP_ENCRYPT_KEY` environment variable. Use a library or utility that supports AES encryption to do this. Here's an example of how to encrypt using go:
 
-```bash
+```go
 package main
 
 import (
@@ -195,7 +195,7 @@ curl --location 'http://localhost:9013/things/bootstrap/secure/<external_id>' \
 
 Finally, decrypt the response using a function. Here's an example of how to do this using go:
 
-```bash
+```go
 package main
 
 import (

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -118,11 +118,11 @@ curl -s -S -i -X PUT -H "Authorization: Bearer <user_token>" -H "Content-Type: a
 
 In order to disconnect, the same request should be sent with the value of `state` set to 0.
 
-### Getting secure bootstrap configuration
+### Using curl request for secure bootstrap configuration
 
 Here is a guide on how to get secure bootstrap configuration.
 
-- **Encrypt the External Key.**
+- *Encrypt the external key.*
 
 First, you need to encrypt the external key of your thing using AES encryption. The encryption key is specified by the `MG_BOOTSTRAP_ENCRYPT_KEY` environment variable. You can use a library or utility that supports AES encryption to do this. Here's an example of how you encrypt using golang:
 ```bash
@@ -159,7 +159,7 @@ func main() {
 	data := []byte("<external_key>")
 
 	r := reader{
-		encKey: []byte("<encryption_key>"),
+		encKey: []byte("<crypto_key>"),
 	}
 
 	encryptedData, err := r.encrypt(data)
@@ -170,13 +170,11 @@ func main() {
 
 	fmt.Printf("%x\n", encryptedData)
 }
-
 ```
 
-Replace `<external_key>` and `<encryption_key>` with your thing's external key and encryption key respectively.
+Replace `<external_key>` and `<crypto_key>` with your thing's external key and `MG_BOOTSTRAP_ENCRYPT_KEY` respectively.
 
-
-- **Make a Request to the Bootstrap Service.**
+- *Make a request to the bootstrap service.*
 
 
 Once you have the encrypted external key, you can make a request to the Bootstrap service. Here's how you can do this using `curl`:
@@ -185,6 +183,7 @@ curl --location 'http://localhost:9013/things/bootstrap/secure/<external_id>' \
 --header 'Accept: application/json' \
 --header 'authorization: Thing <encyrpted_external_key>' --output -
 ```
+
 The response from the Bootstrap service will be in encrypted binary format. You can store this response in a file for later use.
 
 ```bash
@@ -193,7 +192,7 @@ curl --location 'http://localhost:9013/things/bootstrap/secure/<external_id>' \
 --header 'authorization: Thing <encyrpted_external_key>' --output ~/<desired\>/<path\>/<file_name.txt>
 ```
 
-- **Decrypt the Response**
+- *Decrypt the response*
 
 Finally, you can decrypt the response using a function. Here's an example of how you can do this using golang:
 
@@ -214,7 +213,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	key := []byte("<encryption_key>")
+	key := []byte("<crypto_key>")
 
 	block, err := aes.NewCipher(key)
 	if err != nil {
@@ -235,6 +234,22 @@ func main() {
 		log.Fatal(err)
 	}
 }
+```
+
+>Note: If you are making the request via the Magistrala CLI, this process is not required.
+
+
+### Using Magistrala CLI for secure bootstrap configuration
+
+If you prefer to use the Magistrala CLI for the secure bootstrap configuration, you can do so with the following command:
+
+```bash
+magistrala_cli bootstrap secure <external_id> <external_key> <crypto_key>
+```
+for example
+
+```bash
+cli bootstrap bootstrap secure '09:6:0:sb:sa' 'key' 'v7aT0HGxJxt2gULzr3RHwf4WIf6DusPp'
 ```
 
 

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -207,7 +207,6 @@ import (
 )
 
 func main() {
-
 	encodedData, err := os.ReadFile("~/<desired\>/<path\>/<enc_file_name.txt>")
 	if err != nil {
 		log.Fatal(err)
@@ -238,7 +237,7 @@ func main() {
 
 ### Using Magistrala CLI for secure bootstrap configuration
 
-To use Magistrala CLI for the secure bootstrap configuration, use  the following command:
+To use Magistrala CLI for the secure bootstrap configuration, use the following command:
 
 ```bash
 magistrala_cli bootstrap secure <external_id> <external_key> <crypto_key>

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -122,7 +122,7 @@ In order to disconnect, the same request should be sent with the value of `state
 
 - *Encrypt the external key.*
 
-First, encrypt the external key of your thing using AES encryption. The encryption key is specified by the `MG_BOOTSTRAP_ENCRYPT_KEY` environment variable. Use a library or utility that supports AES encryption to do this. Here's an example of how to encrypt using GO:
+First, encrypt the external key of your thing using AES encryption. The encryption key is specified by the `MG_BOOTSTRAP_ENCRYPT_KEY` environment variable. Use a library or utility that supports AES encryption to do this. Here's an example of how to encrypt using Go:
 
 ```go
 package main
@@ -194,7 +194,7 @@ curl --location 'http://localhost:9013/things/bootstrap/secure/<external_id>' \
 
 - *Decrypt the response*
 
-Finally, decrypt the response using a function. Here's an example of how to do this using GO:
+Finally, decrypt the response using a function. Here's an example of how to do this using Go:
 
 ```go
 package main

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -120,11 +120,9 @@ In order to disconnect, the same request should be sent with the value of `state
 
 ### Using curl request for secure bootstrap configuration
 
-Here is a guide on how to get secure bootstrap configuration.
-
 - *Encrypt the external key.*
 
-First, you need to encrypt the external key of your thing using AES encryption. The encryption key is specified by the `MG_BOOTSTRAP_ENCRYPT_KEY` environment variable. You can use a library or utility that supports AES encryption to do this. Here's an example of how you encrypt using golang:
+First, encrypt the external key of your thing using AES encryption. The encryption key is specified by the `MG_BOOTSTRAP_ENCRYPT_KEY` environment variable. Use a library or utility that supports AES encryption to do this. Here's an example of how to encrypt using golang:
 ```bash
 package main
 
@@ -172,19 +170,19 @@ func main() {
 }
 ```
 
-Replace `<external_key>` and `<crypto_key>` with your thing's external key and `MG_BOOTSTRAP_ENCRYPT_KEY` respectively.
+Replace `<external_key>` and `<crypto_key>` with the thing's external key and `MG_BOOTSTRAP_ENCRYPT_KEY` respectively.
 
 - *Make a request to the bootstrap service.*
 
 
-Once you have the encrypted external key, you can make a request to the Bootstrap service. Here's how you can do this using `curl`:
+Once the key is encrypted, make a request to the Bootstrap service. Here's how to do this using `curl`:
 ```bash
 curl --location 'http://localhost:9013/things/bootstrap/secure/<external_id>' \
 --header 'Accept: application/json' \
 --header 'authorization: Thing <encyrpted_external_key>' --output -
 ```
 
-The response from the Bootstrap service will be in encrypted binary format. You can store this response in a file for later use.
+The response from the Bootstrap service will be in encrypted binary format. Store this response in a file for later use.
 
 ```bash
 curl --location 'http://localhost:9013/things/bootstrap/secure/<external_id>' \
@@ -194,7 +192,7 @@ curl --location 'http://localhost:9013/things/bootstrap/secure/<external_id>' \
 
 - *Decrypt the response*
 
-Finally, you can decrypt the response using a function. Here's an example of how you can do this using golang:
+Finally, decrypt the response using a function. Here's an example of how to do this using golang:
 
 ```bash
 package main
@@ -236,12 +234,9 @@ func main() {
 }
 ```
 
->Note: If you are making the request via the Magistrala CLI, this process is not required.
-
-
 ### Using Magistrala CLI for secure bootstrap configuration
 
-If you prefer to use the Magistrala CLI for the secure bootstrap configuration, you can do so with the following command:
+To use Magistrala CLI for the secure bootstrap configuration, use  the following command:
 
 ```bash
 magistrala_cli bootstrap secure <external_id> <external_key> <crypto_key>

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -118,6 +118,126 @@ curl -s -S -i -X PUT -H "Authorization: Bearer <user_token>" -H "Content-Type: a
 
 In order to disconnect, the same request should be sent with the value of `state` set to 0.
 
+### Getting secure bootstrap configuration
+
+Here is a guide on how to get secure bootstrap configuration.
+
+- **Encrypt the External Key.**
+
+First, you need to encrypt the external key of your thing using AES encryption. The encryption key is specified by the `MG_BOOTSTRAP_ENCRYPT_KEY` environment variable. You can use a library or utility that supports AES encryption to do this. Here's an example of how you encrypt using golang:
+```bash
+package main
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"fmt"
+	"io"
+)
+
+type reader struct {
+	encKey []byte
+}
+
+func (r reader) encrypt(in []byte) ([]byte, error) {
+	block, err := aes.NewCipher(r.encKey)
+	if err != nil {
+		return nil, err
+	}
+	ciphertext := make([]byte, aes.BlockSize+len(in))
+	iv := ciphertext[:aes.BlockSize]
+	if _, err := io.ReadFull(rand.Reader, iv); err != nil {
+		return nil, err
+	}
+	stream := cipher.NewCFBEncrypter(block, iv)
+	stream.XORKeyStream(ciphertext[aes.BlockSize:], in)
+	return ciphertext, nil
+}
+
+func main() {
+	data := []byte("<external_key>")
+
+	r := reader{
+		encKey: []byte("<encryption_key>"),
+	}
+
+	encryptedData, err := r.encrypt(data)
+	if err != nil {
+		fmt.Println("Error encrypting data:", err)
+		return
+	}
+
+	fmt.Printf("%x\n", encryptedData)
+}
+
+```
+
+Replace `<external_key>` and `<encryption_key>` with your thing's external key and encryption key respectively.
+
+
+- **Make a Request to the Bootstrap Service.**
+
+
+Once you have the encrypted external key, you can make a request to the Bootstrap service. Here's how you can do this using `curl`:
+```bash
+curl --location 'http://localhost:9013/things/bootstrap/secure/<external_id>' \
+--header 'Accept: application/json' \
+--header 'authorization: Thing <encyrpted_external_key>' --output -
+```
+The response from the Bootstrap service will be in encrypted binary format. You can store this response in a file for later use.
+
+```bash
+curl --location 'http://localhost:9013/things/bootstrap/secure/<external_id>' \
+--header 'Accept: application/json' \
+--header 'authorization: Thing <encyrpted_external_key>' --output ~/<desired\>/<path\>/<file_name.txt>
+```
+
+- **Decrypt the Response**
+
+Finally, you can decrypt the response using a function. Here's an example of how you can do this using golang:
+
+```bash
+package main
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"log"
+	"os"
+)
+
+func main() {
+
+	encodedData, err := os.ReadFile("~/<desired\>/<path\>/<enc_file_name.txt>")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	key := []byte("<encryption_key>")
+
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if len(encodedData) < aes.BlockSize {
+		log.Fatal("ciphertext too short")
+	}
+
+	iv := encodedData[:aes.BlockSize]
+	encodedData = encodedData[aes.BlockSize:]
+	stream := cipher.NewCFBDecrypter(block, iv)
+	stream.XORKeyStream(encodedData, encodedData)
+
+	err = os.WriteFile("~/<desired\>/<path\>/<decry_file_name.txt>", encodedData, 0644)
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+```
+
+
 For more information about the Bootstrap service API, please check out the [API documentation][api-docs].
 
 [image-1]: img/bootstrap/1.png


### PR DESCRIPTION
### What does this do?
This commit guides the user on how to get secure bootstrap configuration. It shows how to encrypt the thing's 
`external key` and then decry-pt the response.

### Which issue(s) does this PR fix/relate to?
There was no open issue related to this.

### List any changes that modify/break current functionality
This commit does not modify or break any current functionality. It guides the user on how to get secure bootstrap configuration.

### Have you included tests for your changes?
No
### Did you document any new/modified functionality?
No
### Notes
